### PR TITLE
Added commands to add and remove players from viewing personal breadcrumbs

### DIFF
--- a/src/main/java/logan/api/util/Functions.kt
+++ b/src/main/java/logan/api/util/Functions.kt
@@ -15,6 +15,10 @@ fun CommandSender.sendMessage(message: String, translateColorCodes: Boolean) {
     )
 }
 
+fun CommandSender.sendColoredFormattedMessage(message: String, vararg params: Any) {
+    sendMessage(String.format(message, params), true)
+}
+
 fun CommandSender.hasNoPermission(node: String): Boolean {
     return !this.hasPermission(node)
 }

--- a/src/main/java/logan/breadcrumbs/BreadcrumbParticle.kt
+++ b/src/main/java/logan/breadcrumbs/BreadcrumbParticle.kt
@@ -20,7 +20,7 @@ class BreadcrumbParticle(val playerId: UUID, val location: Location, var color: 
     fun activate() {
         spawnerTask = Bukkit.getScheduler().runTaskTimer(BreadcrumbsPlugin.instance, {
             viewers.forEach { viewerId ->
-                val viewer = Bukkit.getPlayer(viewerId)
+                val viewer = viewerId.bukkitPlayer ?: return@forEach
                     viewer.spawnParticle(
                         Particle.REDSTONE, location, Config.getCount(),
                         Config.getSpread(), 0.0, Config.getSpread(),

--- a/src/main/java/logan/breadcrumbs/BreadcrumbParticle.kt
+++ b/src/main/java/logan/breadcrumbs/BreadcrumbParticle.kt
@@ -8,6 +8,14 @@ import org.bukkit.entity.Player
 import org.bukkit.scheduler.BukkitTask
 import java.util.*
 
+/**
+ * Represents a breadcrumb particle that is emitted by a player.
+ *
+ * @param playerId The UUID of the player emitting the particle.
+ * @param location The location where the particle should be spawned.
+ * @param color The color of the particle.
+ * @param duration The duration of the particle in milliseconds.
+ */
 class BreadcrumbParticle(val playerId: UUID, val location: Location, var color: Color, var duration: Long) {
     private lateinit var spawnerTask: BukkitTask
     private val viewers = mutableSetOf<UUID>()
@@ -17,6 +25,16 @@ class BreadcrumbParticle(val playerId: UUID, val location: Location, var color: 
         activate()
     }
 
+    /**
+     * Activates the particle emission.
+     *
+     * This method starts a task that repeatedly emits particles with the configured settings.
+     * The particles are emitted at the specified emission frequency and spread around the
+     * specified location. The color and size of the particles are also determined by the
+     * configuration.
+     *
+     * @throws IllegalStateException if the Bukkit scheduler is not available.
+     */
     fun activate() {
         spawnerTask = Bukkit.getScheduler().runTaskTimer(BreadcrumbsPlugin.instance, {
             viewers.forEach { viewerId ->

--- a/src/main/java/logan/breadcrumbs/BreadcrumbsPlugin.kt
+++ b/src/main/java/logan/breadcrumbs/BreadcrumbsPlugin.kt
@@ -36,8 +36,8 @@ class BreadcrumbsPlugin : JavaPlugin() {
         registerEvents()
         registerCommands()
         startBreadcrumbPlaceTimer()
-        startBreadcrumbDurationTimer()
-        startBreadcrumbUpdateTimer()
+        startBreadcrumbDurationMonitor()
+        startBreadcrumbVisibilityUpdater()
 
         logger.info("$name enabled.")
     }
@@ -82,6 +82,20 @@ class BreadcrumbsPlugin : JavaPlugin() {
         server.pluginManager.registerEvents(PlayerJoinListener(), this)
     }
 
+    /**
+     * Starts a timer to periodically place breadcrumbs for players.
+     *
+     * This method uses a Bukkit scheduler to run a task at regular intervals.
+     * The task iterates through the `playersWithBreadcrumbs` map, checks if
+     * any active breadcrumbs are close to the player, and resets their duration.
+     * If no active breadcrumbs are close to the player, a new breadcrumb is placed
+     * and added to the player's breadcrumb list.
+     *
+     * @see Config.getPlaceFrequency
+     * @see BreadcrumbParticle.isActive
+     * @see Player.isCloseToBreadcrumb
+     * @see placeBreadcrumbForPlayer
+     */
     private fun startBreadcrumbPlaceTimer() {
         Bukkit.getScheduler().runTaskTimer(this, {
             playersWithBreadcrumbs.forEach outer@{ (playerId, breadcrumbList) ->
@@ -107,7 +121,12 @@ class BreadcrumbsPlugin : JavaPlugin() {
         )
     }
 
-    private fun startBreadcrumbDurationTimer() {
+    /**
+     * Starts a timer to monitor the duration of active breadcrumbs for all players.
+     * The duration for each breadcrumb will be decremented by 1 at each tick of the timer,
+     * and any breadcrumbs with a duration less than or equal to 0 will be deactivated and removed.
+     */
+    private fun startBreadcrumbDurationMonitor() {
         Bukkit.getScheduler().runTaskTimer(this, {
             playersWithBreadcrumbs.forEach { (_, breadcrumbList) ->
                 breadcrumbList.removeIf { breadcrumb ->
@@ -123,7 +142,11 @@ class BreadcrumbsPlugin : JavaPlugin() {
         }, 20, 20)
     }
 
-    private fun startBreadcrumbUpdateTimer() {
+    /**
+     * Starts a timer that updates the visibility of breadcrumbs for all players.
+     * This method is called internally by the plugin and is not meant to be accessed directly.
+     */
+    private fun startBreadcrumbVisibilityUpdater() {
         Bukkit.getScheduler().runTaskTimer(this, {
             for (entry in playersWithBreadcrumbs.entries) {
                 for (onlinePlayer in Bukkit.getOnlinePlayers()) {

--- a/src/main/java/logan/breadcrumbs/BreadcrumbsPlugin.kt
+++ b/src/main/java/logan/breadcrumbs/BreadcrumbsPlugin.kt
@@ -7,6 +7,7 @@ import org.bukkit.Bukkit
 import org.bukkit.ChatColor
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
 import org.bukkit.plugin.java.JavaPlugin
 import java.io.IOException
 import java.nio.file.Files
@@ -84,25 +85,25 @@ class BreadcrumbsPlugin : JavaPlugin() {
     private fun startBreadcrumbPlaceTimer() {
         Bukkit.getScheduler().runTaskTimer(this, {
             playersWithBreadcrumbs.forEach outer@{ (playerId, breadcrumbList) ->
+                val player = playerId.bukkitPlayer ?: return@outer
                 breadcrumbList.filter(BreadcrumbParticle::isActive).forEach inner@{ breadcrumb ->
-                    val player = playerId.bukkitPlayer
                     if (player.isCloseToBreadcrumb(breadcrumb)) {
                         breadcrumb.resetDuration()
                         return@outer
                     }
                 }
-                val breadcrumb = placeBreadcrumbForPlayer(playerId)
+                val breadcrumb = placeBreadcrumbForPlayer(player)
                 breadcrumbList.add(breadcrumb)
             }
         }, Config.getPlaceFrequency(), Config.getPlaceFrequency())
     }
 
-    private fun placeBreadcrumbForPlayer(playerId: UUID): BreadcrumbParticle {
+    private fun placeBreadcrumbForPlayer(player: Player): BreadcrumbParticle {
         return BreadcrumbParticle(
-            playerId,
-            playerId.bukkitPlayer.location,
-            PlayerConfig.getColor(playerId),
-            PlayerConfig.getDuration(playerId)
+            player.uniqueId,
+            player.location,
+            PlayerConfig.getColor(player.uniqueId),
+            PlayerConfig.getDuration(player.uniqueId)
         )
     }
 

--- a/src/main/java/logan/breadcrumbs/BreadcrumbsPlugin.kt
+++ b/src/main/java/logan/breadcrumbs/BreadcrumbsPlugin.kt
@@ -150,14 +150,6 @@ class BreadcrumbsPlugin : JavaPlugin() {
      */
     private fun startBreadcrumbVisibilityUpdater() {
         Bukkit.getScheduler().runTaskTimer(this, {
-            for (entry in playersWithBreadcrumbs.entries) {
-                for (onlinePlayer in Bukkit.getOnlinePlayers()) {
-                    for (nearbyBreadcrumb in onlinePlayer.nearbyBreadcrumbs(entry.value, Config.getViewDistance())) {
-                        nearbyBreadcrumb.addViewerOfNotAlreadyViewing(onlinePlayer.uniqueId)
-                    }
-                }
-            }
-
             updateBreadcrumbsVisibility()
         }, 20, 20)
     }

--- a/src/main/java/logan/breadcrumbs/BreadcrumbsPlugin.kt
+++ b/src/main/java/logan/breadcrumbs/BreadcrumbsPlugin.kt
@@ -76,6 +76,8 @@ class BreadcrumbsPlugin : JavaPlugin() {
         CommandDispatcher.registerCommand(ToggleCommand())
         CommandDispatcher.registerCommand(ReloadCommand())
         CommandDispatcher.registerCommand(ColorCommand())
+        CommandDispatcher.registerCommand(AddCommand())
+        CommandDispatcher.registerCommand(RemoveCommand())
     }
 
     private fun registerEvents() {

--- a/src/main/java/logan/breadcrumbs/Commands.kt
+++ b/src/main/java/logan/breadcrumbs/Commands.kt
@@ -134,3 +134,24 @@ class AddCommand : BasicCommand<Player>(
         return true
     }
 }
+
+class RemoveCommand : BasicCommand<Player>(
+    "remove",
+    "breadcrumbs.remove",
+    1..1,
+    target = SenderTarget.PLAYER,
+    parentCommand = "breadcrumbs",
+    argTypes = listOf(String::class),
+) {
+    override fun run(sender: Player, args: Array<out String>, data: Any?): Boolean {
+        val playerToRemove = Bukkit.getPlayer(args[0]) ?: run {
+            sender.sendMessage(Config.getCannotFindPlayerMessage())
+            return true
+        }
+        playersWithBreadcrumbs[sender.uniqueId]?.forEach {
+            it.removeViewer(playerToRemove.uniqueId)
+        }
+        sender.sendMessage(Config.getRemoveViewerSuccessMessage())
+        return true
+    }
+}

--- a/src/main/java/logan/breadcrumbs/Commands.kt
+++ b/src/main/java/logan/breadcrumbs/Commands.kt
@@ -6,6 +6,7 @@ import logan.api.util.isHexColor
 import logan.api.util.isRgbColor
 import logan.api.util.sendMessage
 import logan.api.util.toBukkitColor
+import org.bukkit.Bukkit
 import org.bukkit.Color
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
@@ -109,6 +110,27 @@ class ColorCommand : BasicCommand<Player>(
         val newColor = PlayerConfig.getColor(sender.uniqueId)
         playersWithBreadcrumbs[sender.uniqueId]?.forEach { it.color = newColor }
         sender.sendMessage(Config.getPrefix() + " " + String.format(Config.getSetColorMessage(), newColor.red, newColor.green, newColor.blue), true)
+        return true
+    }
+}
+
+class AddCommand : BasicCommand<Player>(
+    "add",
+    "breadcrumbs.add",
+    1..1,
+    target = SenderTarget.PLAYER,
+    parentCommand = "breadcrumbs",
+    argTypes = listOf(String::class),
+) {
+    override fun run(sender: Player, args: Array<out String>, data: Any?): Boolean {
+        val playerToAdd = Bukkit.getPlayer(args[0]) ?: run {
+            sender.sendMessage(Config.getCannotFindPlayerMessage())
+            return true
+        }
+        playersWithBreadcrumbs[sender.uniqueId]?.forEach {
+            it.addViewerOfNotAlreadyViewing(playerToAdd.uniqueId)
+        }
+        sender.sendMessage(Config.getAddViewerSuccessMessage())
         return true
     }
 }

--- a/src/main/java/logan/breadcrumbs/Commands.kt
+++ b/src/main/java/logan/breadcrumbs/Commands.kt
@@ -2,10 +2,7 @@ package logan.breadcrumbs
 
 import logan.api.command.BasicCommand
 import logan.api.command.SenderTarget
-import logan.api.util.isHexColor
-import logan.api.util.isRgbColor
-import logan.api.util.sendMessage
-import logan.api.util.toBukkitColor
+import logan.api.util.*
 import org.bukkit.Bukkit
 import org.bukkit.Color
 import org.bukkit.command.CommandSender
@@ -130,8 +127,7 @@ class AddCommand : BasicCommand<Player>(
         playersWithBreadcrumbs[sender.uniqueId]?.forEach {
             it.addViewerOfNotAlreadyViewing(playerToAdd.uniqueId)
         }
-        val formattedMessage = String.format(Config.getAddViewerSuccessMessage(), playerToAdd.name)
-        sender.sendMessage(formattedMessage, true)
+        sender.sendColoredFormattedMessage(Config.getAddViewerSuccessMessage(), playerToAdd.name)
         return true
     }
 }
@@ -152,8 +148,7 @@ class RemoveCommand : BasicCommand<Player>(
         playersWithBreadcrumbs[sender.uniqueId]?.forEach {
             it.removeViewer(playerToRemove.uniqueId)
         }
-        val formattedMessage = String.format(Config.getRemoveViewerSuccessMessage(), playerToRemove.name)
-        sender.sendMessage(formattedMessage, true)
+        sender.sendColoredFormattedMessage(Config.getRemoveViewerSuccessMessage(), playerToRemove.name)
         return true
     }
 }

--- a/src/main/java/logan/breadcrumbs/Commands.kt
+++ b/src/main/java/logan/breadcrumbs/Commands.kt
@@ -124,13 +124,14 @@ class AddCommand : BasicCommand<Player>(
 ) {
     override fun run(sender: Player, args: Array<out String>, data: Any?): Boolean {
         val playerToAdd = Bukkit.getPlayer(args[0]) ?: run {
-            sender.sendMessage(Config.getCannotFindPlayerMessage())
+            sender.sendMessage(Config.getCannotFindPlayerMessage(), true)
             return true
         }
         playersWithBreadcrumbs[sender.uniqueId]?.forEach {
             it.addViewerOfNotAlreadyViewing(playerToAdd.uniqueId)
         }
-        sender.sendMessage(Config.getAddViewerSuccessMessage())
+        val formattedMessage = String.format(Config.getAddViewerSuccessMessage(), playerToAdd.name)
+        sender.sendMessage(formattedMessage, true)
         return true
     }
 }
@@ -145,13 +146,14 @@ class RemoveCommand : BasicCommand<Player>(
 ) {
     override fun run(sender: Player, args: Array<out String>, data: Any?): Boolean {
         val playerToRemove = Bukkit.getPlayer(args[0]) ?: run {
-            sender.sendMessage(Config.getCannotFindPlayerMessage())
+            sender.sendMessage(Config.getCannotFindPlayerMessage(), true)
             return true
         }
         playersWithBreadcrumbs[sender.uniqueId]?.forEach {
             it.removeViewer(playerToRemove.uniqueId)
         }
-        sender.sendMessage(Config.getRemoveViewerSuccessMessage())
+        val formattedMessage = String.format(Config.getRemoveViewerSuccessMessage(), playerToRemove.name)
+        sender.sendMessage(formattedMessage, true)
         return true
     }
 }

--- a/src/main/java/logan/breadcrumbs/Commands.kt
+++ b/src/main/java/logan/breadcrumbs/Commands.kt
@@ -74,7 +74,7 @@ class ToggleCommand : BasicCommand<Player>(
                 )
             )
 
-            sender.sendMessage(PREFIX + " " + Config.getToggleOnMessage(), true)
+            sender.sendMessage(Config.getPrefix() + " " + Config.getToggleOnMessage(), true)
         }
         return true
     }
@@ -127,7 +127,7 @@ class AddCommand : BasicCommand<Player>(
         playersWithBreadcrumbs[sender.uniqueId]?.forEach {
             it.addViewerOfNotAlreadyViewing(playerToAdd.uniqueId)
         }
-        sender.sendColoredFormattedMessage(Config.getAddViewerSuccessMessage(), playerToAdd.name)
+        sender.sendColoredFormattedMessage(Config.getPrefix() + " " + Config.getAddViewerSuccessMessage(), playerToAdd.name)
         return true
     }
 }
@@ -148,7 +148,7 @@ class RemoveCommand : BasicCommand<Player>(
         playersWithBreadcrumbs[sender.uniqueId]?.forEach {
             it.removeViewer(playerToRemove.uniqueId)
         }
-        sender.sendColoredFormattedMessage(Config.getRemoveViewerSuccessMessage(), playerToRemove.name)
+        sender.sendColoredFormattedMessage(Config.getPrefix() + " " + Config.getRemoveViewerSuccessMessage(), playerToRemove.name)
         return true
     }
 }

--- a/src/main/java/logan/breadcrumbs/Config.kt
+++ b/src/main/java/logan/breadcrumbs/Config.kt
@@ -19,6 +19,9 @@ object Config {
     fun getSetColorMessage() = configuration.getString("message.set-color", "Set breadcrumb color to %d, %d, %d.")
 
     fun getUnknownColorMessage() = configuration.getString("message.unknown-color", "Unknown color: %s.")
+    fun getCannotFindPlayerMessage() = configuration.getString("message.cannot-find-player", "Cannot find player: %s.")
+
+    fun getAddViewerSuccessMessage() = configuration.getString("message.viewer-add-success", "Successfully added %s as a viewer.")
 
     fun getColor() = configuration.getString("breadcrumbs.color")!!.toBukkitColor()
 

--- a/src/main/java/logan/breadcrumbs/Config.kt
+++ b/src/main/java/logan/breadcrumbs/Config.kt
@@ -23,6 +23,8 @@ object Config {
 
     fun getAddViewerSuccessMessage() = configuration.getString("message.viewer-add-success", "Successfully added %s as a viewer.")
 
+    fun getRemoveViewerSuccessMessage() = configuration.getString("message.viewer-remove-success", "Successfully removed %s as a viewer.")
+
     fun getColor() = configuration.getString("breadcrumbs.color")!!.toBukkitColor()
 
     fun getSize() = configuration.getDouble("breadcrumbs.size", 1.0).toFloat()

--- a/src/main/java/logan/breadcrumbs/Extensions.kt
+++ b/src/main/java/logan/breadcrumbs/Extensions.kt
@@ -4,8 +4,8 @@ import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import java.util.*
 
-val UUID.bukkitPlayer: Player
-    get() = Bukkit.getPlayer(this)
+val UUID.bukkitPlayer: Player?
+    get() = Bukkit.getPlayer(this) ?: null
 
 fun Player.nearbyBreadcrumbs(breadcrumbs: List<BreadcrumbParticle>, distance: Int): List<BreadcrumbParticle> {
     return breadcrumbs.filter { it.location.distance(this.location) <= distance }

--- a/src/main/java/logan/breadcrumbs/Listeners.kt
+++ b/src/main/java/logan/breadcrumbs/Listeners.kt
@@ -4,6 +4,7 @@ import org.bukkit.ChatColor
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
 
 class PlayerJoinListener : Listener {
     @EventHandler
@@ -11,6 +12,14 @@ class PlayerJoinListener : Listener {
         if (event.player.isOp) {
             if (updated) event.player.sendMessage("$PREFIX ${ChatColor.GREEN}You're up to date!")
             else event.player.sendMessage("$PREFIX ${ChatColor.YELLOW}There is a new update available! (v${BreadcrumbsPlugin.instance.description.version} -> v$newVersion)")
+        }
+    }
+
+    @EventHandler
+    fun onPlayerLeave(event: PlayerQuitEvent) {
+        val player = event.player
+        playersWithBreadcrumbs[player.uniqueId]?.forEach {
+            it.deactivate()
         }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -76,5 +76,11 @@ message:
   # when changing the breadcrumb color.
   unknown-color: "Unknown color: %s."
 
+  # The message send when the player specified in a command
+  # doesn't exist or isn't online.
+  cannot-find-player: "Cannot find player: %s."
+
+  # The message sent when a player is added as a viewer to their breadcrumbs.
+  add-viewer-success: "Successfully added %s as a viewer."
 
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -83,4 +83,6 @@ message:
   # The message sent when a player is added as a viewer to their breadcrumbs.
   add-viewer-success: "Successfully added %s as a viewer."
 
+  # The message sent when a player is removed as a viewer to their breadcrumbs.
+  remove-viewer-success: "Successfully removed %s as a viewer."
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -54,11 +54,6 @@ breadcrumbs:
   # 32 blocks = 2 chunks.
   view-distance: 16
 
-  # If true, everybody can see each other's breadcrumbs.
-  # If false, players can only see their own breadcrumbs, and players can only see each
-  # others breadcrumbs if they add other viewers to them via command.
-  multiplayer: false
-
 message:
   # The message sent when the configuration file is reloaded.
   reload: "Reloaded config."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,12 @@ permissions:
   breadcrumbs.use:
     description: Allows toggling of breadcrumbs.
     default: true
+  breadcrumbs.add:
+    description: Allows adding players as viewers of breadcrumbs.
+    default: true
+  breadcrumbs.remove:
+    description: Allows removing players as viewers of breadcrumbs.
+    default: true
   breadcrumbs.color:
     description: Allows changing of breadcrumbs color.
   breadcrumbs.reload:


### PR DESCRIPTION
Adds an 'add' and 'remove' command for adding a player as a viewer of someones breadcrumbs, and removing a player as a viewer of someones breadcrumbs.

This allows players to control who can see their breadcrumbs.